### PR TITLE
Make use of Delayed::Backend::Base#name for performable method

### DIFF
--- a/lib/delayed/class_name/plugin.rb
+++ b/lib/delayed/class_name/plugin.rb
@@ -8,7 +8,7 @@ module Delayed
           if Delayed::ClassName.configuration.custom_parser?
             job.class_name = Delayed::ClassName.configuration.custom_parser.call payload_object
           else
-            job.class_name = payload_object.class.name
+            job.class_name = job.name
           end
         end
       end

--- a/lib/delayed/class_name/plugin.rb
+++ b/lib/delayed/class_name/plugin.rb
@@ -3,10 +3,8 @@ module Delayed
     class Plugin < Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.before(:enqueue) do |job|
-          payload_object = job.payload_object
-
           if Delayed::ClassName.configuration.custom_parser?
-            job.class_name = Delayed::ClassName.configuration.custom_parser.call payload_object
+            job.class_name = Delayed::ClassName.configuration.custom_parser.call job.payload_object
           else
             job.class_name = job.name
           end

--- a/spec/delayed/class_name_spec.rb
+++ b/spec/delayed/class_name_spec.rb
@@ -10,9 +10,18 @@ describe Delayed::ClassName do
       end
     end
 
-    it 'assigns the class name of the payload object to class_name' do
-      Delayed::Job.enqueue TestJob.new
-      expect(job.class_name).to eq 'TestJob'
+    context 'when your job has a display_name method' do
+      it 'assigns the display name of the payload object to class_name' do
+        Delayed::Job.enqueue TestJobWithDisplayName.new
+        expect(job.class_name).to eq 'TestDisplayName'
+      end
+    end
+
+    context 'when your job does not have a display name method' do
+      it 'assigns the class name of the payload object to class_name' do
+        Delayed::Job.enqueue TestJob.new
+        expect(job.class_name).to eq 'TestJob'
+      end
     end
   end
 

--- a/spec/support/test_job_with_display_name.rb
+++ b/spec/support/test_job_with_display_name.rb
@@ -1,0 +1,8 @@
+class TestJobWithDisplayName
+  def perform
+  end
+
+  def display_name
+    "TestDisplayName"
+  end
+end


### PR DESCRIPTION
Just a thought! This will help when a job is delayed using the `.delay` syntax, because the payload object class will just be `Delayed::PerformableMethod`. But using the built in `Delayed::Backend::Base#name` method (https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/backend/base.rb#L60), it makes use of PerformableMethod's `display_name` (https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/performable_method.rb#L17).

This does not work with ActiveJob, unfortunately, so you would still need to use a custom parser